### PR TITLE
Update smoke-tests.yml

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 18
-          cache: "npm" # cache node_modules
+          cache: "npm"
 
       - name: Install dependencies
         run: npm ci
@@ -32,11 +32,26 @@ jobs:
       - name: Install Playwright browsers
         run: npx playwright install --with-deps
 
-      - name: Run Playwright smoke tests
-        run: npx playwright test --grep @smoke --reporter=line
-
-      - name: Send Teams Notification
+      - name: Run Playwright smoke tests with HTML + JSON report
         run: |
+          npx playwright test --grep @smoke --reporter=json,html > results.json
+
+      - name: Deploy Playwright report to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./playwright-report
+
+      - name: Parse results and send summary to Teams
+        run: |
+          echo "📊 Formatting Playwright results..."
+          summary=$(jq -r '
+            .suites[].specs[] | 
+            .title + " → " + (.tests[0].results[0].status)
+          ' results.json | sed ':a;N;$!ba;s/\n/\\n/g')
+
+          report_url="https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/"
+
           curl -H 'Content-Type: application/json' \
-           -d '{"text": "✅ Playwright smoke tests completed successfully"}' \
-           ${{ secrets.TEAMS_WEBHOOK_URL }}
+            -d "{\"text\": \"🧪 Playwright Smoke Test Report\n$summary\n\n📑 [View Full HTML Report]($report_url)\"}" \
+            ${{ secrets.TEAMS_WEBHOOK_URL }}


### PR DESCRIPTION
### Summary

This update configures our Playwright smoke test workflow to automatically generate and publish test reports to **GitHub Pages**. The reports are then shared in Microsoft Teams along with a test summary.

### Key Changes

* **Added GitHub Actions step** to deploy the Playwright HTML report using [`peaceiris/actions-gh-pages`](https://github.com/peaceiris/actions-gh-pages).
* **Automatic branch creation**: If the `gh-pages` branch does not exist, the workflow will create and maintain it.
* **Updated Teams notification**: Each run now includes a summary of test cases (name + pass/fail) and a link to the hosted HTML report.
* **Hosting reports online**: Reports are now viewable directly in the browser at:

  ``` https://<username>.github.io/<repo>/ ```

### Benefits

* Teams will receive **detailed test summaries + direct links** to reports.
* The HTML report is **always accessible online**, removing the need to download artifacts.
* Simplifies collaboration and debugging by making reports shareable across the team.

### Next Steps

* After the first workflow run, set **GitHub Pages** source to:

  * **Branch** → `gh-pages`
  * **Folder** → `/ (root)`

This ensures future runs automatically update the hosted report.