### PR TITLE
Update smoke test workflow for report handling with old and new results

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -34,24 +34,27 @@ jobs:
 
       - name: Run Playwright smoke tests with HTML + JSON report
         run: |
-          npx playwright test --grep @smoke --reporter=json,html > results.json
+          mkdir -p reports
+          npx playwright test --grep @smoke --reporter=json,html
+          mv playwright-report "reports/$(date +'%Y-%m-%d_%H-%M-%S')"
 
-      - name: Deploy Playwright report to GitHub Pages
+      - name: Deploy Playwright reports to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./playwright-report
+          publish_dir: ./reports
+          publish_branch: gh-pages
+          keep_files: true  # keep older reports instead of deleting them
 
       - name: Parse results and send summary to Teams
         run: |
-          echo "📊 Formatting Playwright results..."
           summary=$(jq -r '
             .suites[].specs[] | 
             .title + " → " + (.tests[0].results[0].status)
-          ' results.json | sed ':a;N;$!ba;s/\n/\\n/g')
+          ' reports/*/results.json | sed ':a;N;$!ba;s/\n/\\n/g')
 
-          report_url="https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/"
+          latest_url="https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/$(ls -t reports | head -n1)/"
 
           curl -H 'Content-Type: application/json' \
-            -d "{\"text\": \"🧪 Playwright Smoke Test Report\n$summary\n\n📑 [View Full HTML Report]($report_url)\"}" \
+            -d "{\"text\": \"🧪 Playwright Smoke Test Report\n$summary\n\n📑 [View Latest Report]($latest_url)\"}" \
             ${{ secrets.TEAMS_WEBHOOK_URL }}


### PR DESCRIPTION
This pull request improves the Playwright smoke test workflow by organizing test reports into timestamped directories, enabling retention of historical reports, and updating the notification logic to always link to the latest report. The changes enhance report management and make it easier to access previous test results.

**Report Management Improvements:**

* Playwright HTML and JSON reports are now saved in timestamped directories under `reports/`, allowing multiple test runs to be retained instead of overwriting the previous report. (`.github/workflows/smoke-tests.yml`)
* The GitHub Pages deployment step now publishes the entire `reports/` directory and keeps older reports, enabling browsing of historical test results. (`.github/workflows/smoke-tests.yml`)

**Notification Logic Updates:**

* The Teams notification now parses results from all `results.json` files in the `reports/` directory and provides a direct link to the latest report using a timestamped path. (`.github/workflows/smoke-tests.yml`)Creates a new folder under reports/YYYY-MM-DD_HH-MM-SS/ (e.g., reports/2025-09-17_04-00-00/).

Stores both index.html and results.json inside.