### PR TITLE
changes done for failed report

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -145,7 +145,7 @@ jobs:
             message_failed=$'\n'"❌ Failed/Flaky Tests:"$'\n'"${failed_flaky}"
           fi
           
-          message_links=$'\n'"📑 View Full Report  🔗 [View Workflow](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})"
+          message_links=$'\n'"📑 View Full Report  🔗 [View Workflow](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})"$'\n\n'"---"$'\n'"👤 **Sent by:** Navaneetha B | 🕐 **Time:** $(TZ='Asia/Kolkata' date +'%a %b %d %Y, %I:%M:%S %p IST')"
           
           # Combine all parts
           full_message="${message_header}"$'\n\n'"${message_summary}"$'\n\n'"${message_tests}${message_failed}${message_links}"


### PR DESCRIPTION
This pull request makes a small update to the workflow notification message in `.github/workflows/smoke-tests.yml`. The change adds sender information and a timestamp to the end of the workflow report message for better traceability.